### PR TITLE
Adding single quotes to osfamily case choices

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -50,18 +50,18 @@ class killall($ensure='running',
   }
 
   case $::osfamily {
-    Debian: {
+    'Debian': {
       $supported  = true
       $pkg_name   = [ 'psmisc' ]
       $svc_name   = 'psmisc'
     }
-    RedHat: {
+    'RedHat': {
       $supported  = true
       $pkg_name   = [ 'killall' ]
       $svc_name   = 'killall'
     }
 
-    Linux: {
+    'Linux': {
       if ($::operatingsystem == 'Archlinux') {
         $supported = true
         $pkg_name = ['killall']


### PR DESCRIPTION
Adding single quotes fixes an error in puppet 4.

Puppet::PreformattedError:
       Evaluation Error: Resource type not found: Debian
